### PR TITLE
Install only dev dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ runs:
         path: "~/.cache/pypoetry/virtualenvs/"
         key: "${{ runner.os }}-poetry-${{ steps.python-setup.outputs.python-version }}-${{ hashFiles('./poetry.lock') }}${{ inputs.cache-version }}"
     - name: "Install environment"
-      run: "poetry install"
+      run: "poetry install --only=dev"
       shell: "bash"


### PR DESCRIPTION
I propose this poetry action only install dev dependencies.  the tests we do all run locally and this will speed up installs