### PR TITLE
Install Virtualenv 20.30.0 if Poetry version is <2.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,12 +49,8 @@ runs:
       run: "ln -s /root/.local/bin/poetry /usr/local/bin/poetry"
       shell: "bash"
     - name: "Install Virtualenv compatible with Poetry 1.X"
-      run: |
-        POETRY_VERSION=$(poetry --version | awk '{print $2}')
-        if [[ $(printf "%s\n" "$POETRY_VERSION" "2.0.0" | sort -V | head -n 1) != "$POETRY_VERSION" ]]; then
-          echo "Poetry version is less than 2.0.0"
-          ~/.local/share/pypoetry/venv/bin/pip install virtualenv==20.30.0
-        fi
+      if: startsWith(inputs.poetry-version, '1.')
+      run: poetry self add @20.30.0
       shell: "bash"
     - name: "Log: Check cache"
       run: "echo Checking cache"

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,14 @@ runs:
     - name: "Add poetry to PATH"
       run: "ln -s /root/.local/bin/poetry /usr/local/bin/poetry"
       shell: "bash"
+    - name: "Install Virtualenv compatible with Poetry 1.X"
+      run: |
+        POETRY_VERSION=$(poetry --version | awk '{print $2}')
+        if [[ $(printf "%s\n" "$POETRY_VERSION" "2.0.0" | sort -V | head -n 1) != "$POETRY_VERSION" ]]; then
+          echo "Poetry version is less than 2.0.0"
+          ~/.local/share/pypoetry/venv/bin/pip install virtualenv==20.30.0
+        fi
+      shell: "bash"
     - name: "Log: Check cache"
       run: "echo Checking cache"
       shell: "bash"

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
       shell: "bash"
     - name: "Install Virtualenv compatible with Poetry 1.X"
       if: startsWith(inputs.poetry-version, '1.')
-      run: poetry self add @20.30.0
+      run: poetry self add virtualenv@20.30.0
       shell: "bash"
     - name: "Log: Check cache"
       run: "echo Checking cache"

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
       shell: "bash"
     - name: "Install Virtualenv compatible with Poetry 1.X"
       if: startsWith(inputs.poetry-version, '1.')
-      run: poetry self add virtualenv@20.30.0
+      run: "poetry self add virtualenv@20.30.0"
       shell: "bash"
     - name: "Log: Check cache"
       run: "echo Checking cache"

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
       run: "ln -s /root/.local/bin/poetry /usr/local/bin/poetry"
       shell: "bash"
     - name: "Install Virtualenv compatible with Poetry 1.X"
-      if: startsWith(inputs.poetry-version, '1.')
+      if: "startsWith(inputs.poetry-version, '1.')"
       run: "poetry self add virtualenv@20.30.0"
       shell: "bash"
     - name: "Log: Check cache"


### PR DESCRIPTION
This PR adds a step in the pipeline to install a version of virtualenv if Poetry is <2.0.0, for instance 1.8.5.  This checks the installed version of poetry, so it doesn't matter if Poetry is passed into the CI as an argument or not.

This is to resolve the issue documented at https://github.com/python-poetry/poetry/issues/10378
